### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-win:
     name: Build Windows Installer
@@ -67,6 +70,8 @@ jobs:
     name: Append Assets to Release
     runs-on: ubuntu-latest
     needs: [build-win, build-mac]
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Potential fix for [https://github.com/StoppedwummPython/minecraft-launcher/security/code-scanning/4](https://github.com/StoppedwummPython/minecraft-launcher/security/code-scanning/4)

Add explicit `permissions` in `.github/workflows/release.yml`:

1. Define a restrictive default at workflow root:
   - `contents: read` (sufficient for checkout and general read operations).
2. Override only the `append-assets` job with:
   - `contents: write` (needed to upload release assets via `softprops/action-gh-release`).

This preserves existing behavior while enforcing least privilege:
- `build-win` and `build-mac` keep read-only token scope.
- `append-assets` gets write access only where required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
